### PR TITLE
Add support for DNS SOA record and improve tests

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -31,7 +31,7 @@ namespace tuposoft {
     template<typename T = std::uint16_t>
     auto write_big_endian(std::ostream &output, T val) -> decltype(output) {
         std::array<char, sizeof(val)> buffer{};
-        auto val_be = htons(val);
+        const auto val_be = htons(val);
         std::memcpy(buffer.data(), &val_be, sizeof(val));
         output.write(buffer.data(), buffer.size());
         return output;

--- a/include/dns_answer.hpp
+++ b/include/dns_answer.hpp
@@ -2,6 +2,7 @@
 
 #include "dns_record_e.hpp"
 #include "mx_rdata.hpp"
+#include "soa_rdata.hpp"
 
 #include <tuple>
 
@@ -14,6 +15,11 @@ namespace tuposoft {
     template<>
     struct rdata<dns_record_e::MX> {
         using type = mx_rdata;
+    };
+
+    template<>
+    struct rdata<dns_record_e::SOA> {
+        using type = soa_rdata;
     };
 
     template<dns_record_e T>
@@ -39,6 +45,9 @@ namespace tuposoft {
 
     template<>
     auto parse_rdata<dns_record_e::AAAA>(std::istream &input) -> rdata<dns_record_e::AAAA>::type;
+
+    template<>
+    auto parse_rdata<dns_record_e::SOA>(std::istream &input) -> rdata<dns_record_e::SOA>::type;
 
     template<dns_record_e T>
     auto operator>>(std::istream &input, dns_answer<T> &answer) -> decltype(input) {

--- a/include/mx_rdata.hpp
+++ b/include/mx_rdata.hpp
@@ -11,6 +11,4 @@ namespace tuposoft {
     auto operator==(const mx_rdata &, const mx_rdata &) -> bool;
 
     auto tie_mx_rdata(const mx_rdata &);
-
-    auto operator>>(std::istream &input, mx_rdata &mx_rdata) -> decltype(input);
 } // namespace tuposoft

--- a/include/soa_rdata.hpp
+++ b/include/soa_rdata.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace tuposoft {
+    struct soa_rdata {
+        std::string mname;
+        std::string rname;
+        std::uint32_t serial;
+        std::uint32_t refresh;
+        std::uint32_t retry;
+        std::uint32_t expire;
+        std::uint32_t minimum;
+    };
+
+    auto tie_soa_rdata(const soa_rdata &);
+
+    auto operator==(const soa_rdata &, const soa_rdata &) -> bool;
+}; // namespace tuposoft

--- a/source/dns_answer.cpp
+++ b/source/dns_answer.cpp
@@ -32,3 +32,13 @@ auto tuposoft::parse_rdata<dns_record_e::AAAA>(std::istream &input) -> rdata<dns
 
     return str_ipv6.data();
 }
+
+template<>
+auto tuposoft::parse_rdata<dns_record_e::SOA>(std::istream &input) -> rdata<dns_record_e::SOA>::type {
+    return {
+            from_dns_label_format(input),          from_dns_label_format(input),
+            read_big_endian<std::uint32_t>(input), read_big_endian<std::uint32_t>(input),
+            read_big_endian<std::uint32_t>(input), read_big_endian<std::uint32_t>(input),
+            read_big_endian<std::uint32_t>(input),
+    };
+}

--- a/source/dns_header.cpp
+++ b/source/dns_header.cpp
@@ -7,14 +7,14 @@ constexpr unsigned OPCODE_MASK = 0xFU;
 constexpr unsigned RCODE_MASK = 0xFU;
 
 namespace tuposoft {
-    auto header_flags_to_short(const dns_header &header) -> unsigned short {
+    auto header_flags_to_short(const dns_header &header) -> std::uint16_t {
         return header.rd << RD_POSITION | header.tc << TC_POSITION | header.aa << AA_POSITION |
                header.opcode << OPCODE_POSITION | header.qr << QR_POSITION | header.rcode << RCODE_POSITION |
                header.cd << CD_POSITION | header.ad << AD_POSITION | header.z << Z_POSITION | header.ra << RA_POSITION;
     }
 
     auto tie_dns_header(const dns_header &header) {
-        return std::tie(header.id, *std::make_unique<unsigned short>(header_flags_to_short(header)), header.qdcount,
+        return std::tie(header.id, *std::make_unique<std::uint16_t>(header_flags_to_short(header)), header.qdcount,
                         header.ancount, header.nscount, header.arcount);
     }
 

--- a/source/mx_rdata.cpp
+++ b/source/mx_rdata.cpp
@@ -5,12 +5,6 @@
 namespace tuposoft {
     auto tie_mx_rdata(const mx_rdata &rdata) { return std::tie(rdata.preference, rdata.mx); }
 
-    auto operator>>(std::istream &input, mx_rdata &mx_rdata) -> decltype(input) {
-        mx_rdata.preference = read_big_endian<std::uint16_t>(input);
-        mx_rdata.mx = from_dns_label_format(input);
-        return input;
-    }
-
     auto operator==(const mx_rdata &first, const mx_rdata &second) -> bool {
         return tie_mx_rdata(first) == tie_mx_rdata(second);
     }

--- a/source/soa_rdata.cpp
+++ b/source/soa_rdata.cpp
@@ -1,0 +1,12 @@
+#include "soa_rdata.hpp"
+#include "common.hpp"
+
+#include <tuple>
+
+auto tuposoft::tie_soa_rdata(const soa_rdata &rdata) {
+    return std::tie(rdata.mname, rdata.rname, rdata.serial, rdata.refresh, rdata.retry, rdata.expire, rdata.minimum);
+}
+
+auto tuposoft::operator==(const soa_rdata &lhs, const soa_rdata &rhs) -> bool {
+    return tie_soa_rdata(lhs) == tie_soa_rdata(rhs);
+}


### PR DESCRIPTION
Support for DNS SOA record has been added by implementing SOA related functionality in necessary areas. Removal of functions related to mx_rdata was carried out as well. Additionally, tests have been amended to ensure correctness, including an improvement in naming conventions and the addition of a new 'dns_response' test for SOA records.